### PR TITLE
Added support for headers to avoid HTTP error 403

### DIFF
--- a/linkstatus/linkstatus.py
+++ b/linkstatus/linkstatus.py
@@ -3,6 +3,7 @@ import os
 from shutil import get_terminal_size
 
 import click
+import pkg_resources
 import requests
 
 from linkstatus.parser import link_validator
@@ -20,7 +21,9 @@ def link_status(link, timeout=5):
     Returns:
         tuple of status (bool) and status code
     """
-    headers = {"User-Agent": "linkstatus/0.8"}
+    headers = {
+        "User-Agent": "linkstatus/{}".format(pkg_resources.get_distribution("linkstatus").version)
+    }
     try:
         status_code = requests.get(link, headers=headers, timeout=timeout).status_code
     except requests.exceptions.SSLError:

--- a/linkstatus/linkstatus.py
+++ b/linkstatus/linkstatus.py
@@ -20,11 +20,11 @@ def link_status(link, timeout=5):
     Returns:
         tuple of status (bool) and status code
     """
-
+    headers = {"User-Agent": "linkstatus/0.8"}
     try:
-        status_code = requests.get(link, timeout=timeout).status_code
+        status_code = requests.get(link, headers=headers, timeout=timeout).status_code
     except requests.exceptions.SSLError:
-        status_code = requests.get(link, verify=False, timeout=timeout).status_code
+        status_code = requests.get(link, verify=False, headers=headers, timeout=timeout).status_code
     except Exception:  # noqa
         # TODO: include exception in logging
         status_code = None


### PR DESCRIPTION
Added support for headers to avoid HTTP error 403 due to robots.txt
One will continue to get 403 if requires web auth forbidden in real.

Following examples which don't work (403 error due to robots.txt) and my CI jobs to fail. Started to work after adding headers support.

- https://www.saltstack.com/resources/community
- https://semaphoreci.com/blog/cicd-pipeline

Fixes #31 

Signed-off-by: Savitoj Singh <savsingh@redhat.com>