### PR TITLE
RFR: new rev for flake8 pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 - repo: https://github.com/asottile/reorder_python_imports
-  rev: v1.9.0
+  rev: v2.1.0
   hooks:
   - id: reorder-python-imports
     language_version: python3
@@ -14,21 +14,21 @@ repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
   rev: v2.5.0
   hooks:
-  -   id: flake8
-      verbose: true
-- repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v2.5.0
-  hooks:
   - id: trailing-whitespace
     language_version: python3
   - id: end-of-file-fixer
     language_version: python3
+  - id: check-yaml
+    language_version: python3
   - id: debug-statements
     language_version: python3
+- repo: https://gitlab.com/pycqa/flake8
+  rev: 3.7.9
+  hooks:
   - id: flake8
     language_version: python3
 - repo: https://github.com/asottile/pyupgrade
-  rev: v2.0.1
+  rev: v2.1.0
   hooks:
   - id: pyupgrade
     language_version: python3


### PR DESCRIPTION
flake8 deprecated from main pre-commit hook

ref: https://github.com/pre-commit/pre-commit-hooks/issues/344